### PR TITLE
Remove `"data_provider": "hiera"` in metadata.json because of deprecation

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,6 +68,5 @@
         "8"
       ]
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
```
Warning: Defining "data_provider": "hiera" in metadata.json is deprecated. It is ignored since a 'hiera.yaml' with version >= 5 is present
```