### PR TITLE
Remove puppetlabs-apt and stahnma-epel as hard dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The tinyproxy module requires the following puppet modules:
 - [puppetlabs-apt](https://forge.puppet.com/puppetlabs/apt) (>= 2.0.0 < 3.0.0) (only Debian-based distributions)
 - [stahnma-epel](https://forge.puppet.com/stahnma/epel) (>= 1.0.0 < 2.0.0) (only RedHat-based distributions)
 
+Both puppetlabs-apt and stahnma-epel are soft dependencies. If you are installing on Debian or RedHat-based systems, you will need to configure appropriate versions of those modules.
+
 ### Beginning with tinyproxy
 
 To install the tinyproxy with default parameters, declare the `tinyproxy` class.

--- a/metadata.json
+++ b/metadata.json
@@ -22,14 +22,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 5.0.0"
-    },
-    {
-      "name": "stahnma-epel",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
-      "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppetlabs-apt and stahnma-epel should be soft dependencies as they are not required under all circumstances by this module. Having them defined as dependencies in metadata.json means that they always get pulled, increasing the spread of modules that need to be installed.